### PR TITLE
[Release/1.0.0-beta.2] Message Menu

### DIFF
--- a/Documentation/Chat_in_Channel/MessageList.md
+++ b/Documentation/Chat_in_Channel/MessageList.md
@@ -97,3 +97,35 @@ var body: some View {
             isKeyboardShown = isShown
         }
 ```
+
+## How to show message menu on long press gesture
+
+You can add message menus to display when a `rowContent`(such as `MessageRow`) is on long press gesture by setting `menuContent` parameter of the `MessageList` initializer.
+
+`MessageMenu` and `MessageMenubuttonStyle` allow you to create message menu more easily. Here is an example:
+
+```swift
+MessageList(messages) { message in
+    // row content
+    MessageRow(message: message)
+        .padding(.top, 12)
+} menuContent: { highlightMessage in 
+    // menu content
+    MessageMenu {
+        Button("Copy", action: copy)
+            .buttonStyle(MessageMenuButtonStyle(symbol: "doc.on.doc"))
+        
+        Divider()
+            
+        Button("Reply", action: reply)
+            .buttonStyle(MessageMenuButtonStyle(symbol: "arrowshape.turn.up.right"))
+            
+        Divider()
+        
+        Button("Delete", action: delete)
+            .buttonStyle(MessageMenuButtonStyle(symbol: "trash"))
+    }
+    .padding(.top, 12)
+}
+``` 
+

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ If you have any feature you want, please let me know via *Issue* or *Discussion*
 - [x]  MessageList: Dimiss keyboard when tap outside
 - [ ]  MessageList: Date view
 - [ ]  MessageList: Publisher for retrieving more message while scrolling
-- [ ]  MessageRow: Message Menu 
+- [x]  MessageList: Message Menu 
+- [x]  MessageList: Message reaction publisher 
 - [ ]  MessageRow: placement (e.g., Both, leftOnly, rightOnly)
 - [ ]  MessageField: CameraCapturer
 - [ ]  Giphy: Resize body with GIF frame size

--- a/Sources/ChatUI/ChatInChannel/MessageMenu/MessageMenu.swift
+++ b/Sources/ChatUI/ChatInChannel/MessageMenu/MessageMenu.swift
@@ -1,0 +1,48 @@
+//
+//  MessageMenu.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/06.
+//
+
+import SwiftUI
+
+/// The menu for the message
+public struct MessageMenu<Content: View>: View {
+    @Environment(\.appearance) var appearance
+    @ViewBuilder let content: () -> Content
+    
+    public var body: some View {
+        VStack(spacing: 0) {
+            content()
+        }
+        .frame(width: 240)
+        .background(appearance.remoteMessageBackground)
+        .cornerRadius(14)
+    }
+    
+    public init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+}
+
+public struct MessageMenuButtonStyle: ButtonStyle {
+    @Environment(\.appearance) var appearance
+    let symbol: String
+
+    public func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.label
+            Spacer()
+            Image(systemName: symbol)
+        }
+        .padding(.horizontal, 16)
+        .foregroundColor(appearance.primary)
+        .background(configuration.isPressed ? appearance.secondaryBackground : Color.clear)
+        .frame(height: 44)
+    }
+    
+    public init(symbol: String) {
+        self.symbol = symbol
+    }
+}

--- a/Sources/ChatUI/ChatInChannel/MessageReaction/ReactionEffectView.swift
+++ b/Sources/ChatUI/ChatInChannel/MessageReaction/ReactionEffectView.swift
@@ -1,0 +1,76 @@
+//
+//  ReactionEffectView.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/05.
+//
+
+import SwiftUI
+
+// - INFORMATION: [Reference - Youtube](https://www.youtube.com/watch?v=S7hhHc9FgnY)
+public struct ReactionEffectView: View {
+    @Environment(\.appearance) var appearance
+    
+    @State var animationValues: [Bool] = Array(repeating: false, count: 6)
+    
+    var item: String
+    var effectTint: Color
+    
+    public var body: some View {
+        ZStack {
+            Text(item)
+                .font(appearance.title)
+                .padding(6)
+                .background {
+                    effectTint
+                        .clipShape(Circle())
+                }
+                .scaleEffect(animationValues[2] ? 1 : 0)
+                .overlay {
+                    Circle()
+                        .stroke(effectTint, lineWidth: animationValues[1] ? 0 : 100)
+                        .clipShape(Circle())
+                        .scaleEffect(animationValues[0] ? 1.6 : 0.01)
+                }
+            // MARK: Random Circles
+                .overlay {
+                    ZStack {
+                        ForEach(1...20, id: \.self) { index in
+                            Circle()
+                                .fill(effectTint)
+                                .frame(width: .random(in: 3...5), height: .random(in: 3...5))
+                                .offset(x: .random(in: -5...5), y: .random(in: -5...5))
+                                .offset(x: animationValues[3] ? 45 : 10)
+                                .rotationEffect(.init(degrees: Double(index) * 18.0))
+                                .scaleEffect(animationValues[2] ? 1 : 0.01)
+                                .opacity(animationValues[4] ? 0 : 1)
+                        }
+                    }
+                }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation(.easeInOut(duration: 0.35)) {
+                    animationValues[0] = true
+                }
+                withAnimation(.easeInOut(duration: 0.45).delay(0.06)) {
+                    animationValues[1] = true
+                }
+                withAnimation(.easeInOut(duration: 0.35).delay(0.3)) {
+                    animationValues[2] = true
+                }
+                withAnimation(.easeInOut(duration: 0.35).delay(0.4)) {
+                    animationValues[3] = true
+                }
+                withAnimation(.easeInOut(duration: 0.55).delay(0.55)) {
+                    animationValues[4] = true
+                }
+            }
+        }
+    }
+    
+    public init(item: String, effectTint: Color) {
+        self.item = item
+        self.effectTint = effectTint
+    }
+}

--- a/Sources/ChatUI/ChatInChannel/MessageReaction/ReactionSelector.swift
+++ b/Sources/ChatUI/ChatInChannel/MessageReaction/ReactionSelector.swift
@@ -1,0 +1,81 @@
+//
+//  ReactionSelector.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/05.
+//
+
+import SwiftUI
+
+public struct ReactionSelector<MessageType: MessageProtocol>: View {
+    @Environment(\.appearance) var appearance
+    
+    @Binding var isPresented: Bool
+    
+    let message: MessageType
+    let items: [String]
+    let onReaction: (String) -> ()
+    
+    
+    // update the count based on your reaction item array size
+    @State var effectItem: [Bool] = Array(repeating: false, count: 5)
+    @State var isEffectAnimated: Bool = false
+    
+    public var body: some View {
+        HStack(spacing: 12) {
+            ForEach(Array(items.enumerated()), id: \.element) { index, item in
+                Text(item)
+                    .font(appearance.title)
+                    .scaleEffect(effectItem[index] ? 1 : 0.1)
+                    .onAppear {
+                        // animate
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            withAnimation(.easeInOut.delay(Double(index) * 0.1)) {
+                                effectItem[index] = true
+                            }
+                        }
+                    }
+                    .onTapGesture {
+                        onReaction(items[index])
+                    }
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 8)
+        .background {
+            Capsule()
+                .fill(appearance.secondaryBackground)
+                .mask {
+                    Capsule()
+                        .scaleEffect(isEffectAnimated ? 1 : 0.1, anchor: .leading)
+                }
+        }
+        .onAppear {
+            withAnimation {
+                isEffectAnimated = true
+            }
+        }
+        .onChange(of: isPresented) { newValue in
+            if !newValue {
+                withAnimation(.easeInOut(duration: 0.2).delay(0.15)) {
+                    isEffectAnimated = true
+                }
+                
+                for index in items.indices {
+                    withAnimation(.easeInOut) {
+                        effectItem[index] = false
+                    }
+                }
+            }
+        }
+    }
+    
+    init(isPresented: Binding<Bool>, message: MessageType, items: [String], onReaction: @escaping (String) -> Void) {
+        self._isPresented = isPresented
+        self.message = message
+        self.items = items
+        self.onReaction = onReaction
+        self.effectItem = effectItem
+        self.isEffectAnimated = isEffectAnimated
+    }
+}

--- a/Sources/ChatUI/ChatInChannel/MessageViews/MessageView.swift
+++ b/Sources/ChatUI/ChatInChannel/MessageViews/MessageView.swift
@@ -1,0 +1,58 @@
+//
+//  MessageView.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/05.
+//
+
+import SwiftUI
+
+struct MessageView: View {
+    @Environment(\.appearance) var appearance
+    
+    let style: MessageStyle
+    let isMyMessage: Bool
+    
+    var body: some View {
+        switch style {
+        case .text(let text):
+            let markdown = LocalizedStringKey(text)
+            Text(markdown)
+                .tint(isMyMessage ? appearance.prominentLink : appearance.link)
+                .messageStyle(isMyMessage ? .localBody : .remoteBody)
+        case .media(let mediaType):
+            switch mediaType {
+            case .emoji(let key):
+                Text(key)
+                    .messageStyle(isMyMessage ? .localBody : .remoteBody)
+            case .gif(let key):
+                GiphyStyleView(id: key)
+            case .photo(let data):
+                PhotoStyleView(data: data)
+            case .video(let data):
+                Text("\(data)")
+                    .lineLimit(5)
+                    .messageStyle(isMyMessage ? .localBody : .remoteBody)
+            case .document(let data):
+                Text("\(data)")
+                    .lineLimit(5)
+                    .messageStyle(isMyMessage ? .localBody : .remoteBody)
+            case .contact(let contact):
+                let markdown = """
+            Name: **\(contact.givenName) \(contact.familyName)**
+            Phone: \(contact.phoneNumbers)
+            """
+                Text(.init(markdown))
+                    .messageStyle(isMyMessage ? .localBody : .remoteBody)
+            case .location(let latitude, let longitude):
+                LocationStyleView(
+                    latitude: latitude,
+                    longitude: longitude
+                )
+            }
+        case .voice(let data):
+            VoiceStyleView(data: data)
+                .messageStyle(isMyMessage ? .localBody : .remoteBody)
+        }
+    }
+}

--- a/Sources/ChatUI/PreferenceKeys/BoundsPreferenceKey.swift
+++ b/Sources/ChatUI/PreferenceKeys/BoundsPreferenceKey.swift
@@ -1,0 +1,17 @@
+//
+//  BoundsPreferenceKey.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/05.
+//
+
+import SwiftUI
+
+/// The preference key to detect anchors of the bounds as `CGRect`
+public struct BoundsPreferenceKey: PreferenceKey {
+    public internal(set) static var defaultValue: [String: Anchor<CGRect>] = [:]
+    
+    public static func reduce(value: inout [String : Anchor<CGRect>], nextValue: () -> [String : Anchor<CGRect>]) {
+        value.merge(nextValue()) { $1 }
+    }
+}

--- a/Sources/ChatUI/PreferenceKeys/ScrollViewOffsetPreferenceKey.swift
+++ b/Sources/ChatUI/PreferenceKeys/ScrollViewOffsetPreferenceKey.swift
@@ -7,10 +7,11 @@
 
 import SwiftUI
 
-struct ScrollViewOffsetPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat? = nil
+/// The preference key to detect scroll view offeset
+public struct ScrollViewOffsetPreferenceKey: PreferenceKey {
+    public internal(set) static var defaultValue: CGFloat? = nil
 
-    static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+    public static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
         value = value ?? nextValue()
     }
 }

--- a/Sources/ChatUI/Previews/ChatInChannel/MessageList.Previews.swift
+++ b/Sources/ChatUI/Previews/ChatInChannel/MessageList.Previews.swift
@@ -32,6 +32,31 @@ struct MessageList_Previews: PreviewProvider {
                 }
             }
             .previewDisplayName("Message List")
+            
+            MessageList(
+                [Message.message1, Message.message2, Message.message3],
+                reactionItems: ["❤️", "👍", "👎", "😆", "🎉"]
+            ) { message in
+                MessageRow(message: message, showsUsername: false, showsProfileImage: false)
+                    .padding(.top, 12)
+            } menuContent: { highlightMessage in
+                MessageMenu {
+                    Button("Copy", action: {})
+                        .buttonStyle(MessageMenuButtonStyle(symbol: "doc.on.doc"))
+                    
+                    Divider()
+                    Button("Reply", action: {})
+                        .buttonStyle(MessageMenuButtonStyle(symbol: "arrowshape.turn.up.right"))
+                    Divider()
+                    Button("Delete", action: {})
+                        .buttonStyle(MessageMenuButtonStyle(symbol: "trash"))
+                }
+                .padding(.top, 12)
+            }
+            .onReceive(messageReactionPublisher) { (item, messageID) in
+                print(item)
+            }
+            .previewDisplayName("Message Menu")
         }
         .environmentObject(
             ChatConfiguration(

--- a/Sources/ChatUI/Protocols/MessageProtocol.swift
+++ b/Sources/ChatUI/Protocols/MessageProtocol.swift
@@ -19,3 +19,20 @@ public protocol MessageProtocol: Hashable {
     var readReceipt: ReadReceipt { get }
     var style: MessageStyle { get }
 }
+
+/// The protocol to support message reaction features.
+/// - IMPORTANT: Currently, it supports single reaction item only that is type of `String`. It's recommeded that uses text emoji such as `"❤️"`, `"🙂"`, `"👍"` and so on.
+public protocol MessageReactable: Hashable {
+    /// The reaction status.
+    /// - SeeAlso: ``ReactionStatus``
+    var reaction: ReactionStatus { get set }
+}
+
+/// The enumeration for message reaction status.
+/// - IMPORTANT: Currently, it supports single reaction item only that is type of `String`. It's recommeded that uses text emoji such as `"❤️"`, `"🙂"`, `"👍"` and so on.
+public enum ReactionStatus: Equatable, Hashable {
+    /// There is no reaction item in which the message has.
+    case none
+    /// There is a single reaction item on the message.
+    case reacted(_ item: String)
+}

--- a/Sources/ChatUI/Publishers/HighlightMessagePublisher.swift
+++ b/Sources/ChatUI/Publishers/HighlightMessagePublisher.swift
@@ -1,0 +1,13 @@
+//
+//  HighlightMessagePublisher.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/05.
+//
+
+import Combine
+
+/**
+ The publisher that send highlight message.
+ */
+public var highlightMessagePublisher = PassthroughSubject<any MessageProtocol, Never>()

--- a/Sources/ChatUI/Publishers/MessageReactionPublisher.swift
+++ b/Sources/ChatUI/Publishers/MessageReactionPublisher.swift
@@ -1,0 +1,15 @@
+//
+//  MessageReactionPublisher.swift
+//  
+//
+//  Created by Jaesung Lee on 2023/03/05.
+//
+
+import Combine
+
+/**
+ The publisher that send reaction item and message ID.
+ - IMPORTANT: The first parameter is the reaction item.
+ */
+public var messageReactionPublisher = PassthroughSubject<(String, String), Never>()
+


### PR DESCRIPTION
- Added `menuContent` to `MessageList` initializer
- Added `MessageMenu`
- Added `ReactionEffectView`, `ReactionSelector`

## How to show message menu on long press gesture

You can add message menus to display when a `rowContent`(such as `MessageRow`) is on long press gesture by setting `menuContent` parameter of the `MessageList` initializer.

`MessageMenu` and `MessageMenubuttonStyle` allow you to create message menu more easily. Here is an example:

```swift
MessageList(messages) { message in
    // row content
    MessageRow(message: message)
        .padding(.top, 12)
} menuContent: { highlightMessage in 
    // menu content
    MessageMenu {
        Button("Copy", action: copy)
            .buttonStyle(MessageMenuButtonStyle(symbol: "doc.on.doc"))
        
        Divider()
            
        Button("Reply", action: reply)
            .buttonStyle(MessageMenuButtonStyle(symbol: "arrowshape.turn.up.right"))
            
        Divider()
        
        Button("Delete", action: delete)
            .buttonStyle(MessageMenuButtonStyle(symbol: "trash"))
    }
    .padding(.top, 12)
}
``` 
